### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
-#WebOverride
+# WebOverride
 WebOverride let's you inject code snippets into any website allowing you to customize it to fit your needs
 - Automatic login
 - hide annoying content
 - create custom shortcuts and so much more...
 
-#What does it do?
+# What does it do?
 Using WebOverride you can inject HTML, CSS and JavaScript into any page in the web.
 You can also import any library you might need from cdnjs.com
 
-#Chrome Store
+# Chrome Store
 You can download the extension from the chrome store and get updated automatically when updates come out.
 <https://chrome.google.com/webstore/detail/web-override/lllllobkincmdnjfkbknjacacmnlajll>
 
-#Setup and run locally
+# Setup and run locally
 - Clone the project
 - Run `bower i` the get the components
 - Open Chrome in `chrome://extensions/`


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
